### PR TITLE
Added local two player mode option, bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ command-line-chess
 
 A python program to play chess against an AI in the terminal.
 
-##Installation
+## Installation
 
 Requires Python 3, run the following to install :
   
     pip3 install cl-chess
 
-##Usage
+## Usage
 
 Run the following command after installation
   
@@ -25,7 +25,7 @@ You can then make any (legal) move :
 
 ![First move](http://i.imgur.com/AsXhhvC.png)
 
-##Options
+## Options
 
 Instead of a move, you can input :
 
@@ -33,6 +33,6 @@ Instead of a move, you can input :
 * `r` to make a random move
 * `u` to undo your last move
 
-##Technical stuff
+## Technical stuff
 
 The AI is a simple brute-force AI with no pruning. It evaluates a given position by counting the value of the pieces for each side (pawn -> 1, knight/bishop -> 3, rook -> 5, queen -> 9). It will evaluate the tree of moves, and take the path that results in the greatest gain. To learn more, check out [my post on how it works] (http://blog.mbuffett.com/creating-a-basic-chess-ai-using-python/).

--- a/src/Board.py
+++ b/src/Board.py
@@ -167,7 +167,7 @@ class Board:
 
     def getCurrentSide(self):
         return self.currentSide
-
+    
     def makeStringRep(self, pieces):
         stringRep = ''
         for y in range(7, -1, -1):
@@ -185,6 +185,34 @@ class Board:
                 else:
                     pieceRep = ' '
                 stringRep += pieceRep + ' '
+            stringRep += '\n'
+        return stringRep.rstrip()
+    
+    def makeUnicodeStringRep(self, pieces):
+        DISPLAY_LOOKUP = {
+            "R": '♜',
+            "N": '♞',
+            "B": '♝',
+            "K": '♚',	
+            "Q": '♛',
+            "P": '♟',
+        }
+
+        stringRep = ''
+        for y in range(7, -1, -1):
+            for x in range(8):
+                piece = None
+                for p in pieces:
+                    if p.position == C(x, y):
+                        piece = p
+                        break
+                on_color = 'on_cyan' if y % 2 == x % 2 else 'on_yellow'
+                pieceRep = colored('  ', on_color=on_color)
+                if piece:
+                    side = piece.side
+                    color = 'white' if side == WHITE else 'grey'
+                    pieceRep = colored(piece.stringRep + ' ', color=color, on_color=on_color)
+                stringRep += pieceRep
             stringRep += '\n'
         return stringRep.rstrip()
 
@@ -232,6 +260,9 @@ class Board:
             notation += str(move.specialMovePiece.stringRep)
 
         return notation
+
+    def currentSideRep(self):
+        return "White" if self.currentSide else "Black"
 
     def getAlgebraicNotationOfMove(self, move, short=True):
         notation = ""

--- a/src/Pawn.py
+++ b/src/Pawn.py
@@ -97,7 +97,7 @@ class Pawn(Piece):
                         lastMoveWasAdvanceTwo = True
 
                 if pieceBesidePawn and \
-                   pieceBesidePawn.stringRep == 'p' and \
+                   pieceBesidePawn.stringRep == 'P' and \
                    pieceBesidePawn.side != self.side and \
                    lastPieceMoved is pieceBesidePawn and \
                    lastMoveWasAdvanceTwo:

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ def askForDepthOfAI():
     try:
         depthInput = int(input("How deep should the AI look for moves?\n"
                                "Warning : values above 3 will be very slow."
-                               " [n]? "))
+                               " [2]? "))
     except:
         print("Invalid input, defaulting to 2")
     return depthInput

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,8 @@ def askForDepthOfAI():
         depthInput = int(input("How deep should the AI look for moves?\n"
                                "Warning : values above 3 will be very slow."
                                " [2]? "))
+    except KeyboardInterrupt:
+        sys.exit()
     except:
         print("Invalid input, defaulting to 2")
     return depthInput
@@ -120,13 +122,60 @@ def startGame(board, playerSide, ai):
             move.notation = parser.notationForMove(move)
             makeMove(move, board)
 
+def twoPlayerGame(board):
+    parserWhite = InputParser(board, WHITE)
+    parserBlack = InputParser(board, BLACK)
+    while True:
+        print()
+        print(board)
+        print()
+        if board.isCheckmate():
+            print("Checkmate")
+            return
+
+        if board.isStalemate():
+            print("Stalemate")
+            return
+
+        # printPointAdvantage(board)
+        if board.currentSide == WHITE:
+            parser = parserWhite
+        else:
+            parser = parserBlack
+        move = None
+        command = input("It's your move, {}.".format(board.currentSideRep()) + \
+                        " Type '?' for options. ? ")
+        if command.lower() == 'u':
+            undoLastTwoMoves(board)
+            continue
+        elif command.lower() == '?':
+            printCommandOptions()
+            continue
+        elif command.lower() == 'l':
+            printAllLegalMoves(board, parser)
+            continue
+        elif command.lower() == 'r':
+            move = getRandomMove(board, parser)
+        elif command.lower() == 'exit' or command.lower() == 'quit':
+            return
+        try:
+            move = parser.parse(command)
+        except ValueError as error:
+            print("%s" % error)
+            continue
+        makeMove(move, board)
+
+
 board = Board()
-playerSide = askForPlayerSide()
-print()
-aiDepth = askForDepthOfAI()
-opponentAI = AI(board, not playerSide, aiDepth)
 
 try:
-    startGame(board, playerSide, opponentAI)
+    if len(sys.argv) >= 2 and sys.argv[1] == "--two":
+        twoPlayerGame(board)
+    else:
+        playerSide = askForPlayerSide()
+        print()
+        aiDepth = askForDepthOfAI()
+        opponentAI = AI(board, not playerSide, aiDepth)
+        startGame(board, playerSide, opponentAI)
 except KeyboardInterrupt:
     sys.exit()


### PR DESCRIPTION
Changes:

- Changed default AI search depth from "[n]" to "[2]"
- En Passant: fixed bug in Pawn.py, line 100, stringRep should be an uppercase 'P' to match the string representation of a Pawn object (?)
- Added local two player mode. Use with "--two" command line argument. 

Other additions:

- Added a `makeUnicodeStringRep` method, same as `makeStringRep`, but prints chess Unicode symbols on a colored checkerboard. This option ought to be another command line argument, but I'm unsure of how to handle this. Would this be best implemented with `argparse`?

- Added a `currentSideRep` method to Board, which returns either "White" or "Black" based on the current side of the board.