### PR TITLE
docs: fix simple typo, unneccesary -> unnecessary

### DIFF
--- a/src/Board.py
+++ b/src/Board.py
@@ -479,7 +479,7 @@ class Board:
         self.undoLastMove()
         return isLegal
 
-    # TODO: remove side parameter, unneccesary
+    # TODO: remove side parameter, unnecessary
     def getAllMovesLegal(self, side):
         unfilteredMoves = list(self.getAllMovesUnfiltered(side))
         legalMoves = []


### PR DESCRIPTION
There is a small typo in src/Board.py.

Should read `unnecessary` rather than `unneccesary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md