### PR TITLE
Add captured pieces to CLI game interface

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -98,12 +98,38 @@ def undoLastTwoMoves(board: Board) -> None:
     else:
         print('Warning: Not enough moves in history to undo.')
 
+def printCapturedPieces(board: Board) -> None:
+    """Display captured pieces for each side based on move history."""
+    DISPLAY_LOOKUP = {
+        'R': '♜',
+        'N': '♞',
+        'B': '♝',
+        'K': '♚',
+        'Q': '♛',
+        '▲': '♟',
+    }
+    captured_pieces = [piece for (_, piece) in board.history if piece is not None]
+    white_captured = [p for p in captured_pieces if p.side is False]
+    black_captured = [p for p in captured_pieces if p.side is True]
+    def pieces_to_string(pieces: list[Piece]) -> str:
+        order = {'Q': 5, 'R': 4, 'B': 3, 'N': 2, '▲': 1, 'K': 0}
+        sorted_pieces = sorted(
+            pieces,
+            key=lambda p: order.get(p.stringRep, 0),
+            reverse=True,
+        )
+        return ''.join(DISPLAY_LOOKUP[p.stringRep] for p in sorted_pieces)
+    white_bar = pieces_to_string(white_captured)
+    black_bar = pieces_to_string(black_captured)
+    print(f"White captured: {white_bar}")
+    print(f"Black captured: {black_bar}")
 
 def printBoard(board: Board) -> None:
     print()
     print(board)
     print()
-
+    printCapturedPieces(board)
+    print()
 
 def printGameMoves(history: list[tuple[Move, Piece | None]]) -> None:
     counter = 0


### PR DESCRIPTION
## Summary
This PR adds a small UX improvement to the CLI: after each board display, the program now shows which pieces have been captured by each side.
This mirrors common chess interfaces and makes terminal play more readable without modifying any engine logic.
Example output:
White captured: ♛♟♟♟
Black captured: ♛♜♝♞♟♟

![Design sans titre](https://github.com/user-attachments/assets/63305ed2-2edb-47e8-8ce3-eeb774211a26)

### Implementation Details
- Added a new helper function `printCapturedPieces(board)` in `src/main.py`.
- Captured pieces are derived from `board.history`, which already stores a tuple `(move, pieceTaken)` for every capture.
- Only `printBoard` was modified to call the new display function.
- Sorting ensures higher-value pieces appear first (Q, R, B, N, P).

### Why This Change?
- This improves the user experience when playing the CLI version.
- Helps players track trades at a glance.
- Adds value without touching game rules, move generation, or core logic. zero risk of regressions




